### PR TITLE
fix: auto send verify request on page load

### DIFF
--- a/cypress/e2e/verify.cy.ts
+++ b/cypress/e2e/verify.cy.ts
@@ -3,15 +3,8 @@ describe('Verify', () => {
   const signature = '0x0000';
   const address = '0x1111';
 
-  beforeEach(() => {
-    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
-  });
-
-  it('shows the verify email button', () => {
-    cy.get('button').contains('Verify email');
-  });
-
   it('sends the correct request body to the backend API', () => {
+    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('verify');
     cy.get('button').click();
 
@@ -26,15 +19,15 @@ describe('Verify', () => {
   });
 
   it('shows the success message when the email is verified', () => {
+    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 });
-    cy.get('button').click();
     cy.get('p').contains('verified');
     cy.get('button').contains('Go back to Snapshot');
   });
 
   it('shows an error message when the verify request is failing', () => {
+    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 });
-    cy.get('button').click();
     cy.get('p').contains('error');
     cy.get('button').contains('Verify email');
   });

--- a/cypress/e2e/verify.cy.ts
+++ b/cypress/e2e/verify.cy.ts
@@ -4,9 +4,8 @@ describe('Verify', () => {
   const address = '0x1111';
 
   it('sends the correct request body to the backend API', () => {
-    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('verify');
-    cy.get('button').click();
+    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
 
     cy.get('@verify').its('request.body').should('deep.equal', {
       method: 'snapshot.verify',
@@ -19,8 +18,8 @@ describe('Verify', () => {
   });
 
   it('shows the success message when the email is verified', () => {
-    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 });
+    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.get('p').contains('verified');
     cy.get('button').contains('Go back to Snapshot');
   });

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -41,7 +41,7 @@ function verify() {
   })
     .then(response => {
       loading.value = false;
-
+      console.log(response.status);
       if (response.status === 200) {
         status.value = Status.SUCCESS;
       } else {

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -41,7 +41,7 @@ function verify() {
   })
     .then(response => {
       loading.value = false;
-      console.log(response.status);
+
       if (response.status === 200) {
         status.value = Status.SUCCESS;
       } else {

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -55,9 +55,7 @@ function verify() {
     });
 }
 
-onMounted(() => {
-  verify();
-});
+onMounted(() => verify());
 </script>
 
 <template>

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSeoMeta } from '@vueuse/head';
 import BaseButton from '@/components/BaseButton.vue';
@@ -54,15 +54,16 @@ function verify() {
       console.log(error);
     });
 }
+
+onMounted(() => {
+  verify();
+});
 </script>
 
 <template>
   <MessageTitle>Verify your email</MessageTitle>
   <div v-if="status === Status.UNKNOWN">
-    <MessageBody>
-      Please verify your email to confirm your subscription to the Snapshot weekly summary.
-    </MessageBody>
-    <BaseButton :loading="loading" primary @click="verify">Verify email</BaseButton>
+    <MessageBody>Please wait while we are verifying your email address.</MessageBody>
   </div>
   <div v-else-if="status === Status.SUCCESS">
     <MessageBody>Your email has been verified.</MessageBody>


### PR DESCRIPTION
This PR auto-trigger the verify request on page load, instead of asking user to click on the `verify` button to verify his email.