### PR TITLE
feat: manage subscription list from unsubscribe page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,5 @@ jobs:
       - run: yarn lint:nofix
       - run: echo "VITE_API_URL=http://localhost:3000" > .env
       - run: yarn build
-      - run: yarn vite preview --port=8080 &
+      - run: yarn vite preview --port=8090 &
       - run: yarn test:e2e

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   video: false,
   e2e: {
     supportFile: false,
-    baseUrl: 'http://localhost:8080',
+    baseUrl: 'http://localhost:8090',
     setupNodeEvents(on, config) {
       dotenv.config();
 

--- a/cypress/e2e/unsubscribe.cy.ts
+++ b/cypress/e2e/unsubscribe.cy.ts
@@ -8,7 +8,7 @@ describe('Unsubscribe', () => {
       body: { summary: { name: 'Summary', description: 'Summary description' } }
     }).as('subscriptionsList');
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('unsubscribe');
-    cy.visit(`unsubscribe?signature=${signature}&email=${email}`);
+    cy.visit(`#/unsubscribe?signature=${signature}&email=${email}`);
     cy.get('[data-test="btn-submit"]').click();
     cy.get('@unsubscribe')
       .its('request.body')
@@ -28,7 +28,7 @@ describe('Unsubscribe', () => {
       body: { summary: { name: 'Summary', description: 'Summary description' } }
     }).as('subscriptionsList');
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('unsubscribe');
-    cy.visit(`unsubscribe?signature=${signature}&email=${email}`);
+    cy.visit(`#/unsubscribe?signature=${signature}&email=${email}`);
     cy.get('form input:first-child()').click();
     cy.get('[data-test="btn-submit"]').click();
     cy.get('[data-test="message-success-unsubscribe"]').should('exist');
@@ -51,7 +51,7 @@ describe('Unsubscribe', () => {
       body: { summary: { name: 'Summary', description: 'Summary description' } }
     }).as('subscriptionsList');
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('unsubscribe');
-    cy.visit(`unsubscribe?signature=${signature}&email=${email}`);
+    cy.visit(`#/unsubscribe?signature=${signature}&email=${email}`);
     cy.get('[data-test="btn-submit"]').click();
     cy.get('[data-test="message-success-update"]').should('exist');
     cy.get('[data-test="btn-redirect"]').should('exist');
@@ -69,7 +69,7 @@ describe('Unsubscribe', () => {
 
   it('shows an error message when the unable to build the subscriptions list', () => {
     cy.intercept('GET', `${Cypress.env('VITE_API_URL')}/subscriptionsList`, { statusCode: 500 });
-    cy.visit('unsubscribe');
+    cy.visit('#/unsubscribe');
     cy.get('[data-test="message-error"]').should('exist');
     cy.get('[data-test="form"]').should('not.exist');
   });
@@ -80,7 +80,7 @@ describe('Unsubscribe', () => {
       body: { summary: { name: 'Summary', description: 'Summary description' } }
     }).as('subscriptionsList');
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 }).as('post');
-    cy.visit('unsubscribe');
+    cy.visit('#/unsubscribe');
     cy.get('[data-test="btn-submit"]').click();
     cy.get('[data-test="message-error"]').should('exist');
     cy.get('[data-test="form"]').should('exist');

--- a/cypress/e2e/unsubscribe.cy.ts
+++ b/cypress/e2e/unsubscribe.cy.ts
@@ -3,34 +3,86 @@ describe('Unsubscribe', () => {
   const signature = '0x0000';
 
   it('sends the correct request body to the backend API', () => {
+    cy.intercept('GET', `${Cypress.env('VITE_API_URL')}/subscriptionsList`, {
+      statusCode: 200,
+      body: { summary: { name: 'Summary', description: 'Summary description' } }
+    }).as('subscriptionsList');
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('unsubscribe');
     cy.visit(`unsubscribe?signature=${signature}&email=${email}`);
-
-    cy.get('@unsubscribe').its('request.body').should('deep.equal', {
-      method: 'snapshot.unsubscribe',
-      params: {
-        email,
-        signature
-      }
-    });
+    cy.get('[data-test="btn-submit"]').click();
+    cy.get('@unsubscribe')
+      .its('request.body')
+      .should('deep.equal', {
+        method: 'snapshot.unsubscribe',
+        params: {
+          email,
+          signature,
+          subscriptions: ['summary']
+        }
+      });
   });
 
-  it('shows the success message when the email is unsubscribed', () => {
-    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 });
+  it('shows the unsubscribe success message when the email is unsubscribed', () => {
+    cy.intercept('GET', `${Cypress.env('VITE_API_URL')}/subscriptionsList`, {
+      statusCode: 200,
+      body: { summary: { name: 'Summary', description: 'Summary description' } }
+    }).as('subscriptionsList');
+    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('unsubscribe');
+    cy.visit(`unsubscribe?signature=${signature}&email=${email}`);
+    cy.get('form input:first-child()').click();
+    cy.get('[data-test="btn-submit"]').click();
+    cy.get('[data-test="message-success-unsubscribe"]').should('exist');
+    cy.get('[data-test="btn-redirect"]').should('exist');
+    cy.get('@unsubscribe')
+      .its('request.body')
+      .should('deep.equal', {
+        method: 'snapshot.unsubscribe',
+        params: {
+          email,
+          signature,
+          subscriptions: []
+        }
+      });
+  });
+
+  it('shows the update success message when the preferences are updated', () => {
+    cy.intercept('GET', `${Cypress.env('VITE_API_URL')}/subscriptionsList`, {
+      statusCode: 200,
+      body: { summary: { name: 'Summary', description: 'Summary description' } }
+    }).as('subscriptionsList');
+    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('unsubscribe');
+    cy.visit(`unsubscribe?signature=${signature}&email=${email}`);
+    cy.get('[data-test="btn-submit"]').click();
+    cy.get('[data-test="message-success-update"]').should('exist');
+    cy.get('[data-test="btn-redirect"]').should('exist');
+    cy.get('@unsubscribe')
+      .its('request.body')
+      .should('deep.equal', {
+        method: 'snapshot.unsubscribe',
+        params: {
+          email,
+          signature,
+          subscriptions: ['summary']
+        }
+      });
+  });
+
+  it('shows an error message when the unable to build the subscriptions list', () => {
+    cy.intercept('GET', `${Cypress.env('VITE_API_URL')}/subscriptionsList`, { statusCode: 500 });
     cy.visit('unsubscribe');
-    cy.get('p').contains('unsubscribed');
-    cy.get('button').contains('Go back to Snapshot');
+    cy.get('[data-test="message-error"]').should('exist');
+    cy.get('[data-test="form"]').should('not.exist');
   });
 
   it('shows an error message when the unsubscribe request is failing', () => {
-    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 });
+    cy.intercept('GET', `${Cypress.env('VITE_API_URL')}/subscriptionsList`, {
+      statusCode: 200,
+      body: { summary: { name: 'Summary', description: 'Summary description' } }
+    }).as('subscriptionsList');
+    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 }).as('post');
     cy.visit('unsubscribe');
-    cy.get('p').contains('error');
-  });
-
-  it('shows a button to retry when the unsubscribe request is failing', () => {
-    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 });
-    cy.visit('unsubscribe');
-    cy.get('button').contains('Unsubscribe');
+    cy.get('[data-test="btn-submit"]').click();
+    cy.get('[data-test="message-error"]').should('exist');
+    cy.get('[data-test="form"]').should('exist');
   });
 });

--- a/cypress/e2e/verify.cy.ts
+++ b/cypress/e2e/verify.cy.ts
@@ -5,7 +5,7 @@ describe('Verify', () => {
 
   it('sends the correct request body to the backend API', () => {
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('verify');
-    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
+    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
 
     cy.get('@verify').its('request.body').should('deep.equal', {
       method: 'snapshot.verify',
@@ -19,14 +19,14 @@ describe('Verify', () => {
 
   it('shows the success message when the email is verified', () => {
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 });
-    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
+    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
     cy.get('[data-test="message-success"]').should('exist');
     cy.get('[data-test="btn-redirect"]').should('exist');
     cy.get('[data-test="btn-verify"]').should('not.exist');
   });
 
   it('shows an error message when the verify request is failing', () => {
-    cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
+    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 });
     cy.get('[data-test="message-error"]').should('exist');
     cy.get('[data-test="btn-verify"]').should('exist');

--- a/cypress/e2e/verify.cy.ts
+++ b/cypress/e2e/verify.cy.ts
@@ -4,7 +4,7 @@ describe('Verify', () => {
   const address = '0x1111';
 
   it('sends the correct request body to the backend API', () => {
-    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 }).as('verify');
+    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200, body: {} }).as('verify');
     cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
 
     cy.get('@verify').its('request.body').should('deep.equal', {
@@ -18,7 +18,7 @@ describe('Verify', () => {
   });
 
   it('shows the success message when the email is verified', () => {
-    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 });
+    cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200, body: {} });
     cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
     cy.get('[data-test="message-success"]').should('exist');
     cy.get('[data-test="btn-redirect"]').should('exist');

--- a/cypress/e2e/verify.cy.ts
+++ b/cypress/e2e/verify.cy.ts
@@ -20,14 +20,16 @@ describe('Verify', () => {
   it('shows the success message when the email is verified', () => {
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200 });
     cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
-    cy.get('p').contains('verified');
-    cy.get('button').contains('Go back to Snapshot');
+    cy.get('[data-test="message-success"]').should('exist');
+    cy.get('[data-test="btn-redirect"]').should('exist');
+    cy.get('[data-test="btn-verify"]').should('not.exist');
   });
 
   it('shows an error message when the verify request is failing', () => {
     cy.visit(`verify?address=${address}&signature=${signature}&email=${email}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 });
-    cy.get('p').contains('error');
-    cy.get('button').contains('Verify email');
+    cy.get('[data-test="message-error"]').should('exist');
+    cy.get('[data-test="btn-verify"]').should('exist');
+    cy.get('[data-test="btn-redirect"]').should('not.exist');
   });
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
+    "@vueuse/core": "^10.1.2",
     "@vueuse/head": "^1.1.23",
     "dotenv": "^16.0.3",
     "vue": "^3.2.47",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "dev": "vite --port=8080",
+    "dev": "vite --port=8090",
     "prebuild": "yarn typecheck",
     "build": "vite build",
     "lint:nofix": "eslint \"./src/**/*.{ts,vue,json}\"",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
-import BrandLogo from '@/components/BrandLogo.vue';
 </script>
 
 <template>
   <div class="grid h-screen place-items-center">
-    <div class="max-w-screen-xs xs:w-[420px] text-center p-5 py-6">
-      <BrandLogo />
-      <RouterView />
-    </div>
+    <RouterView />
   </div>
 </template>

--- a/src/components/BasePage.vue
+++ b/src/components/BasePage.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import BrandLogo from '@/components/BrandLogo.vue';
+import MessageTitle from '@/components/MessageTitle.vue';
+
+withDefaults(defineProps<{ centered?: boolean; title: string }>(), { centered: true });
+</script>
+
+<template>
+  <div :class="['max-w-screen-xs', 'xs:w-[420px]', 'p-5', 'py-6', { 'text-center': centered }]">
+    <BrandLogo />
+    <div v-if="centered" class="space-sep"></div>
+    <div v-else class="line-sep"></div>
+    <MessageTitle>{{ title }}</MessageTitle>
+    <slot />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.line-sep {
+  @apply my-4;
+
+  display: block;
+  height: 2px;
+  background: var(--border-color);
+}
+.space-sep {
+  @apply my-5;
+}
+</style>

--- a/src/components/BrandLogo.vue
+++ b/src/components/BrandLogo.vue
@@ -16,10 +16,6 @@
   }
 }
 
-:global(.brand-logo + *) {
-  @apply mt-4;
-}
-
 @media (prefers-color-scheme: dark) {
   .brand-logo {
     .theme-dark {

--- a/src/components/InputCheckbox.vue
+++ b/src/components/InputCheckbox.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: string[];
+  value: string;
+}>();
+
+const updateValue = () => {
+  const arr = props.modelValue;
+  if (arr.includes(props.value)) {
+    arr.splice(arr.indexOf(props.value), 1);
+  } else {
+    arr.push(props.value);
+  }
+};
+</script>
+
+<template>
+  <label class="flex items-baseline gap-3">
+    <input
+      :v-model="modelValue"
+      :value="value"
+      :checked="modelValue.includes(value)"
+      type="checkbox"
+      class="border-skin-text bg-skin-bg text-primary"
+      @input="updateValue"
+    />
+    <div>
+      <slot />
+    </div>
+  </label>
+</template>

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -16,7 +16,7 @@ defineProps({
 </script>
 
 <template>
-  <BaseLoading class="loading" :class="{ small, big }">
+  <div class="loading" :class="{ small, big }">
     <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
       <path
         :class="{ '!fill-white': fillWhite }"
@@ -32,7 +32,7 @@ defineProps({
         />
       </path>
     </svg>
-  </BaseLoading>
+  </div>
 </template>
 
 <style lang="scss">

--- a/src/components/MessageBox.vue
+++ b/src/components/MessageBox.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+defineProps<{
+  variant?: 'danger';
+}>();
+</script>
+
+<template>
+  <p
+    :class="[
+      'mb-4',
+      'py-3',
+      'px-4',
+      'bg-[#737373]/10',
+      'rounded-md',
+      {
+        'text-red bg-[#ef4444]/10': variant === 'danger'
+      }
+    ]"
+  >
+    <slot />
+  </p>
+</template>

--- a/src/components/RedirectButton.vue
+++ b/src/components/RedirectButton.vue
@@ -7,5 +7,5 @@ function redirect() {
 </script>
 
 <template>
-  <BaseButton @click="redirect">Go back to Snapshot</BaseButton>
+  <BaseButton data-test="btn-redirect" @click="redirect">Go back to Snapshot</BaseButton>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@ import BrandLogo from '@/components/BrandLogo.vue';
 </script>
 
 <template>
-  <div :class="['max-w-screen-xs', 'xs:w-[420px]', 'p-5', 'py-6', { 'text-center': true }]">
+  <div class='max-w-screen-xs xs:w-[420px] p-5 py-6 text-center">
     <BrandLogo />
   </div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@ import BrandLogo from '@/components/BrandLogo.vue';
 </script>
 
 <template>
-  <div class='max-w-screen-xs xs:w-[420px] p-5 py-6 text-center">
+  <div class="max-w-screen-xs xs:w-[420px] p-5 py-6 text-center">
     <BrandLogo />
   </div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,3 +1,9 @@
+<script setup lang="ts">
+import BrandLogo from '@/components/BrandLogo.vue';
+</script>
+
 <template>
-  <main></main>
+  <div :class="['max-w-screen-xs', 'xs:w-[420px]', 'p-5', 'py-6', { 'text-center': true }]">
+    <BrandLogo />
+  </div>
 </template>

--- a/src/views/Unsubscribe.vue
+++ b/src/views/Unsubscribe.vue
@@ -62,7 +62,10 @@ onMounted(() => {
 <template>
   <MessageTitle>Unsubscribe</MessageTitle>
 
-  <div v-if="status === Status.SUCCESS">
+  <div v-if="status === Status.UNKNOWN">
+    <MessageBody>Please wait while we're unsubscribing your email.</MessageBody>
+  </div>
+  <div v-else-if="status === Status.SUCCESS">
     <MessageBody>You have been unsubscribed from the Snapshot weekly summary.</MessageBody>
     <RedirectButton />
   </div>

--- a/src/views/Unsubscribe.vue
+++ b/src/views/Unsubscribe.vue
@@ -29,14 +29,20 @@ useSeoMeta({
 });
 
 async function initForm() {
-  const response = await fetch(`${import.meta.env.VITE_API_URL}/subscriptionsList`);
-  status.value = Status.WAITING;
+  try {
+    const response = await fetch(`${import.meta.env.VITE_API_URL}/subscriptionsList`);
+    status.value = Status.WAITING;
 
-  if (response.status === 200) {
-    subscriptionsList.value = await response.json();
-    updatedSubscriptions.value = Object.keys(subscriptionsList.value);
-  } else {
+    if (response.status === 200) {
+      subscriptionsList.value = await response.json();
+      updatedSubscriptions.value = Object.keys(subscriptionsList.value);
+    } else {
+      status.value = Status.ERROR;
+    }
+  } catch (error) {
     status.value = Status.ERROR;
+    loading.value = false;
+    console.log(error);
   }
 }
 
@@ -77,7 +83,7 @@ async function unsubscribe(subscriptions: string[]) {
 }
 
 const subscriptionsListReady = computed(() => {
-  return Object.keys(subscriptionsList).length > 0;
+  return Object.keys(subscriptionsList.value).length > 0;
 });
 
 onMounted(() => initForm());
@@ -89,21 +95,23 @@ onMounted(() => initForm());
       <MessageBody><LoadingSpinner :big="true" /></MessageBody>
     </div>
     <div v-else-if="status === Status.SUCCESS">
-      <MessageBody v-if="updatedSubscriptions.length === 0">
+      <MessageBody v-if="updatedSubscriptions.length === 0" data-test="message-success-unsubscribe">
         You have been unsubscribed from the Snapshot mailing list.
       </MessageBody>
-      <MessageBody v-else>Your email subscription preferences have been updated.</MessageBody>
+      <MessageBody v-else data-test="message-success-update"
+        >Your email subscription preferences have been updated.</MessageBody
+      >
       <RedirectButton class="mt-3" />
     </div>
     <div v-else class="text-left">
       <div v-if="status === Status.ERROR">
-        <MessageBox variant="danger">
+        <MessageBox data-test="message-error" variant="danger">
           An error occured while processing your request. Please try again, or
           <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a
           >.
         </MessageBox>
       </div>
-      <form v-if="subscriptionsListReady">
+      <form v-if="subscriptionsListReady" data-test="form" @submit.prevent="update">
         <p class="mb-2">Select the email categories you wish to receive:</p>
         <template v-for="(data, key) in subscriptionsList" :key="key">
           <InputCheckbox v-model="updatedSubscriptions" :value="key" class="py-2">
@@ -111,7 +119,13 @@ onMounted(() => initForm());
             <small class="subscription-description">{{ data.description }}</small>
           </InputCheckbox>
         </template>
-        <BaseButton primary :loading="loading" type="submit" class="mt-5" @click="update"
+        <BaseButton
+          primary
+          :loading="loading"
+          data-test="btn-submit"
+          type="submit"
+          class="mt-5"
+          @click.stop="update"
           >Update preferences</BaseButton
         >
         <BaseButton :loading="loading" type="submit" class="mt-3" @click="unsubscribeFromAll"

--- a/src/views/Unsubscribe.vue
+++ b/src/views/Unsubscribe.vue
@@ -1,79 +1,134 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted, Ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSeoMeta } from '@vueuse/head';
-import MessageTitle from '@/components/MessageTitle.vue';
+import BasePage from '@/components/BasePage.vue';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import MessageBody from '@/components/MessageBody.vue';
+import MessageBox from '@/components/MessageBox.vue';
+import InputCheckbox from '@/components/InputCheckbox.vue';
 import RedirectButton from '@/components/RedirectButton.vue';
 import BaseButton from '@/components/BaseButton.vue';
 
 enum Status {
   UNKNOWN,
+  WAITING,
   SUCCESS,
   ERROR
 }
 
 let status = ref(Status.UNKNOWN);
 let loading = ref(false);
+let subscriptionsList: Ref<Record<string, Record<string, string>>> = ref({});
+let updatedSubscriptions: Ref<string[]> = ref([]);
 const route = useRoute();
 
 useSeoMeta({
-  title: 'Unsubscribe',
-  description: 'Unsubscribe from Snapshot weekly summary mailing list'
+  title: 'Manage email subscriptions',
+  description: 'Manage your snapshot mailing subscriptions'
 });
 
-function unsubscribe() {
-  loading.value = true;
+async function initForm() {
+  const response = await fetch(`${import.meta.env.VITE_API_URL}/subscriptionsList`);
+  status.value = Status.WAITING;
 
-  fetch(`${import.meta.env.VITE_API_URL}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      params: {
-        email: route.query.email,
-        signature: route.query.signature
-      },
-      method: 'snapshot.unsubscribe'
-    })
-  })
-    .then(response => {
-      loading.value = false;
-
-      if (response.status === 200) {
-        status.value = Status.SUCCESS;
-      } else {
-        status.value = Status.ERROR;
-      }
-    })
-    .catch(error => {
-      status.value = Status.ERROR;
-      loading.value = false;
-      console.log(error);
-    });
+  if (response.status === 200) {
+    subscriptionsList.value = await response.json();
+    updatedSubscriptions.value = Object.keys(subscriptionsList.value);
+  } else {
+    status.value = Status.ERROR;
+  }
 }
 
-onMounted(() => {
-  unsubscribe();
+function update() {
+  return unsubscribe(updatedSubscriptions.value);
+}
+
+function unsubscribeFromAll() {
+  return unsubscribe([]);
+}
+
+async function unsubscribe(subscriptions: string[]) {
+  loading.value = true;
+
+  try {
+    const response = await fetch(`${import.meta.env.VITE_API_URL}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        params: {
+          email: route.query.email,
+          signature: route.query.signature,
+          subscriptions
+        },
+        method: 'snapshot.unsubscribe'
+      })
+    });
+
+    loading.value = false;
+    status.value = response.status === 200 ? Status.SUCCESS : Status.ERROR;
+  } catch (error) {
+    status.value = Status.ERROR;
+    loading.value = false;
+    console.log(error);
+  }
+}
+
+const subscriptionsListReady = computed(() => {
+  return Object.keys(subscriptionsList).length > 0;
 });
+
+onMounted(() => initForm());
 </script>
 
 <template>
-  <MessageTitle>Unsubscribe</MessageTitle>
-
-  <div v-if="status === Status.UNKNOWN">
-    <MessageBody>Please wait while we're unsubscribing your email.</MessageBody>
-  </div>
-  <div v-else-if="status === Status.SUCCESS">
-    <MessageBody>You have been unsubscribed from the Snapshot weekly summary.</MessageBody>
-    <RedirectButton />
-  </div>
-  <div v-else-if="status === Status.ERROR">
-    <MessageBody variant="danger">
-      An error occured while processing your request. Please try again, or
-      <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a>.
-    </MessageBody>
-    <BaseButton primary :loading="loading" @click="unsubscribe">Unsubscribe</BaseButton>
-  </div>
+  <BasePage title="Email preferences" :centered="false">
+    <div v-if="status === Status.UNKNOWN">
+      <MessageBody><LoadingSpinner :big="true" /></MessageBody>
+    </div>
+    <div v-else-if="status === Status.SUCCESS">
+      <MessageBody v-if="updatedSubscriptions.length === 0">
+        You have been unsubscribed from the Snapshot mailing list.
+      </MessageBody>
+      <MessageBody v-else>Your email subscription preferences have been updated.</MessageBody>
+      <RedirectButton class="mt-3" />
+    </div>
+    <div v-else class="text-left">
+      <div v-if="status === Status.ERROR">
+        <MessageBox variant="danger">
+          An error occured while processing your request. Please try again, or
+          <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a
+          >.
+        </MessageBox>
+      </div>
+      <form v-if="subscriptionsListReady">
+        <p class="mb-2">Select the email categories you wish to receive:</p>
+        <template v-for="(data, key) in subscriptionsList" :key="key">
+          <InputCheckbox v-model="updatedSubscriptions" :value="key" class="py-2">
+            <span class="subscription-name">{{ data.name }}</span>
+            <small class="subscription-description">{{ data.description }}</small>
+          </InputCheckbox>
+        </template>
+        <BaseButton primary :loading="loading" type="submit" class="mt-5" @click="update"
+          >Update preferences</BaseButton
+        >
+        <BaseButton :loading="loading" type="submit" class="mt-3" @click="unsubscribeFromAll"
+          >Unsubscribe from all</BaseButton
+        >
+      </form>
+    </div>
+  </BasePage>
 </template>
+
+<style scoped lang="scss">
+.subscription-name {
+  color: var(--heading-color);
+}
+
+.subscription-description {
+  line-height: 1.5;
+  display: block;
+}
+</style>

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -2,8 +2,8 @@
 import { ref, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSeoMeta } from '@vueuse/head';
+import BasePage from '@/components/BasePage.vue';
 import BaseButton from '@/components/BaseButton.vue';
-import MessageTitle from '@/components/MessageTitle.vue';
 import MessageBody from '@/components/MessageBody.vue';
 import RedirectButton from '@/components/RedirectButton.vue';
 
@@ -19,60 +19,56 @@ const route = useRoute();
 
 useSeoMeta({
   title: 'Verify email',
-  description: 'Verify your email to confirm your subscription to Snapshot weekly summary'
+  description: 'Verify your email to confirm your subscription to Snapshot mailing list'
 });
 
-function verify() {
+async function verify() {
   loading.value = true;
 
-  fetch(`${import.meta.env.VITE_API_URL}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      params: {
-        email: route.query.email,
-        signature: route.query.signature,
-        address: route.query.address
+  try {
+    const response = await fetch(`${import.meta.env.VITE_API_URL}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
       },
-      method: 'snapshot.verify'
-    })
-  })
-    .then(response => {
-      loading.value = false;
-
-      if (response.status === 200) {
-        status.value = Status.SUCCESS;
-      } else {
-        status.value = Status.ERROR;
-      }
-    })
-    .catch(error => {
-      status.value = Status.ERROR;
-      loading.value = false;
-      console.log(error);
+      body: JSON.stringify({
+        params: {
+          email: route.query.email,
+          signature: route.query.signature,
+          address: route.query.address
+        },
+        method: 'snapshot.verify'
+      })
     });
+
+    loading.value = false;
+    status.value = response.status === 200 ? Status.SUCCESS : Status.ERROR;
+  } catch (error) {
+    status.value = Status.ERROR;
+    loading.value = false;
+    console.log(error);
+  }
 }
 
 onMounted(() => verify());
 </script>
 
 <template>
-  <MessageTitle>Verify your email</MessageTitle>
-  <div v-if="status === Status.UNKNOWN">
-    <MessageBody>Please wait while we are verifying your email address.</MessageBody>
-  </div>
-  <div v-else-if="status === Status.SUCCESS">
-    <MessageBody>Your email has been verified.</MessageBody>
-    <RedirectButton />
-  </div>
-  <div v-else>
-    <MessageBody variant="danger">
-      An error occured while verifying your email. Ensure your verification link is correct and try
-      again, or
-      <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a>.
-    </MessageBody>
-    <BaseButton primary :loading="loading" @click="verify">Verify email</BaseButton>
-  </div>
+  <BasePage :centered="true" title="Verify your email">
+    <div v-if="status === Status.UNKNOWN">
+      <MessageBody>Please wait while we are verifying your email address.</MessageBody>
+    </div>
+    <div v-else-if="status === Status.SUCCESS">
+      <MessageBody>Your email has been verified.</MessageBody>
+      <RedirectButton class="mt-3" />
+    </div>
+    <div v-else>
+      <MessageBody variant="danger">
+        An error occured while verifying your email. Ensure your verification link is correct and
+        try again, or
+        <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a>.
+      </MessageBody>
+      <BaseButton primary :loading="loading" @click="verify">Verify email</BaseButton>
+    </div>
+  </BasePage>
 </template>

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSeoMeta } from '@vueuse/head';
+import { useFetch } from '@vueuse/core';
 import BasePage from '@/components/BasePage.vue';
 import BaseButton from '@/components/BaseButton.vue';
 import MessageBody from '@/components/MessageBody.vue';
@@ -23,34 +24,34 @@ useSeoMeta({
 });
 
 async function verify() {
-  loading.value = true;
-
-  try {
-    const response = await fetch(`${import.meta.env.VITE_API_URL}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
+  const fetch = useFetch(import.meta.env.VITE_API_URL, {
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+    .post(() => ({
+      params: {
+        email: route.query.email,
+        signature: route.query.signature,
+        address: route.query.address
       },
-      body: JSON.stringify({
-        params: {
-          email: route.query.email,
-          signature: route.query.signature,
-          address: route.query.address
-        },
-        method: 'snapshot.verify'
-      })
-    });
+      method: 'snapshot.verify'
+    }))
+    .json();
 
-    loading.value = false;
-    status.value = response.status === 200 ? Status.SUCCESS : Status.ERROR;
-  } catch (error) {
+  // eslint-disable-next-line vue/no-ref-as-operand
+  loading = fetch.isFetching;
+
+  fetch.onFetchResponse(() => {
+    status.value = Status.SUCCESS;
+  });
+
+  fetch.onFetchError(() => {
     status.value = Status.ERROR;
-    loading.value = false;
-    console.log(error);
-  }
+  });
 }
 
-onMounted(() => verify());
+onMounted(verify);
 </script>
 
 <template>
@@ -68,9 +69,9 @@ onMounted(() => verify());
         try again, or
         <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a>.
       </MessageBody>
-      <BaseButton primary :loading="loading" data-test="btn-verify" @click="verify"
-        >Verify email</BaseButton
-      >
+      <BaseButton primary :loading="loading" data-test="btn-verify" @click="verify">
+        Verify email
+      </BaseButton>
     </div>
   </BasePage>
 </template>

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -59,16 +59,18 @@ onMounted(() => verify());
       <MessageBody>Please wait while we are verifying your email address.</MessageBody>
     </div>
     <div v-else-if="status === Status.SUCCESS">
-      <MessageBody>Your email has been verified.</MessageBody>
+      <MessageBody data-test="message-success">Your email has been verified.</MessageBody>
       <RedirectButton class="mt-3" />
     </div>
     <div v-else>
-      <MessageBody variant="danger">
+      <MessageBody data-test="message-error" variant="danger">
         An error occured while verifying your email. Ensure your verification link is correct and
         try again, or
         <a title="Contact the support" href="https://discord.snapshot.org/">contact the support</a>.
       </MessageBody>
-      <BaseButton primary :loading="loading" @click="verify">Verify email</BaseButton>
+      <BaseButton primary :loading="loading" data-test="btn-verify" @click="verify"
+        >Verify email</BaseButton
+      >
     </div>
   </BasePage>
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,6 +291,11 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
   integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
+"@types/web-bluetooth@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz#5c9f3c617f64a9735d7b72a7cc671e166d900c40"
+  integrity sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==
+
 "@types/yauzl@^2.9.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
@@ -602,6 +607,16 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.47.tgz#e597ef75086c6e896ff5478a6bfc0a7aa4bbd14c"
   integrity sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==
 
+"@vueuse/core@^10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.1.2.tgz#2499eadec36c5d7109338e3a2b73725040ae8011"
+  integrity sha512-roNn8WuerI56A5uiTyF/TEYX0Y+VKlhZAF94unUfdhbDUI+NfwQMn4FUnUscIRUhv3344qvAghopU4bzLPNFlA==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.17"
+    "@vueuse/metadata" "10.1.2"
+    "@vueuse/shared" "10.1.2"
+    vue-demi ">=0.14.0"
+
 "@vueuse/head@^1.1.23":
   version "1.1.23"
   resolved "https://registry.yarnpkg.com/@vueuse/head/-/head-1.1.23.tgz#a94a4457aed0768d4e9a595097b9d1716a67962b"
@@ -611,6 +626,18 @@
     "@unhead/schema" "^1.1.23"
     "@unhead/ssr" "^1.1.23"
     "@unhead/vue" "^1.1.23"
+
+"@vueuse/metadata@10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.1.2.tgz#d8ffe557b1042efd03a0aa88540a00c25d193ee3"
+  integrity sha512-3mc5BqN9aU2SqBeBuWE7ne4OtXHoHKggNgxZR2K+zIW4YLsy6xoZ4/9vErQs6tvoKDX6QAqm3lvsrv0mczAwIQ==
+
+"@vueuse/shared@10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.1.2.tgz#31d8733a217a6396eb67706319133bf62cdd8baa"
+  integrity sha512-1uoUTPBlgyscK9v6ScGeVYDDzlPSFXBlxuK7SfrDGyUTBiznb3mNceqhwvZHjtDRELZEN79V5uWPTF1VDV8svA==
+  dependencies:
+    vue-demi ">=0.14.0"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2990,6 +3017,11 @@ vitest@^0.29.7:
     vite "^3.0.0 || ^4.0.0"
     vite-node "0.29.7"
     why-is-node-running "^2.2.2"
+
+vue-demi@>=0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.5.tgz#676d0463d1a1266d5ab5cba932e043d8f5f2fbd9"
+  integrity sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==
 
 vue-eslint-parser@^9.0.1:
   version "9.1.0"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

There is currently no page to allow user to update his subscription preferences, only a unsubscribe page.

## 💊 Fixes / Solution

Fix #4

Add a new form to the unsubscribe page, inviting user to `update` and choose what emails to receive, in addition to `unsubscribe`, as a last resort to retain him.

## 🚧 Changes

- Add a form to the unsubscribe page, before the UNSUBSCRIBE button, to invite user to update his subscription preferences, instead of unsubscribing

Has to be tested with this PR of envelop backend https://github.com/snapshot-labs/envelop/pull/55