### PR TITLE
fix: fix missing salt params when verifying email

### DIFF
--- a/cypress/e2e/verify.cy.ts
+++ b/cypress/e2e/verify.cy.ts
@@ -2,31 +2,33 @@ describe('Verify', () => {
   const email = 'test@snapshot.org';
   const signature = '0x0000';
   const address = '0x1111';
+  const salt = '10';
 
   it('sends the correct request body to the backend API', () => {
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200, body: {} }).as('verify');
-    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
+    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}&salt=${salt}`);
 
     cy.get('@verify').its('request.body').should('deep.equal', {
       method: 'snapshot.verify',
       params: {
         email,
         address,
-        signature
+        signature,
+        salt
       }
     });
   });
 
   it('shows the success message when the email is verified', () => {
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 200, body: {} });
-    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
+    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}&salt=${salt}`);
     cy.get('[data-test="message-success"]').should('exist');
     cy.get('[data-test="btn-redirect"]').should('exist');
     cy.get('[data-test="btn-verify"]').should('not.exist');
   });
 
   it('shows an error message when the verify request is failing', () => {
-    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}`);
+    cy.visit(`#/verify?address=${address}&signature=${signature}&email=${email}&salt=${salt}`);
     cy.intercept('POST', Cypress.env('VITE_API_URL'), { statusCode: 500 });
     cy.get('[data-test="message-error"]').should('exist');
     cy.get('[data-test="btn-verify"]').should('exist');

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -33,7 +33,8 @@ async function verify() {
       params: {
         email: route.query.email,
         signature: route.query.signature,
-        address: route.query.address
+        address: route.query.address,
+        salt: route.query.salt
       },
       method: 'snapshot.verify'
     }))


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Related to https://github.com/snapshot-labs/envelop/issues/126

Verification link is ignoring `salt` params, failing all verification requests

## 💊 Fixes / Solution

Add missing `salt` params

## 🚧 Changes

- Fetch and send the `salt` params from the url to the verification request

## 🛠️ Tests

- Send a subscribe email to yourself using the test scripts in envelop
- Click on the verify link in the email
- The verification page url should contains a salt params, and should send a POST request back to envelop, with `salt` in the body