### PR TITLE
chore: exclude browser extension errors from Sentry

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -12,6 +12,7 @@ export const initSentry = (app, router) => {
     ],
     tracesSampleRate: parseFloat(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE),
     replaysSessionSampleRate: parseFloat(import.meta.env.VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE),
-    replaysOnErrorSampleRate: parseFloat(import.meta.env.VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE)
+    replaysOnErrorSampleRate: parseFloat(import.meta.env.VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE),
+    denyUrls: [/extensions\//i, /^chrome:\/\//i, /^chrome-extension:\/\//i]
   });
 };


### PR DESCRIPTION
Exclude browser extension errors from Sentry